### PR TITLE
Remove warning about archiving the account owner

### DIFF
--- a/sections/users.md
+++ b/sections/users.md
@@ -50,7 +50,7 @@ POST /api/v1/users
 
 ### Deleting vs Archiving
 
-A user cannot be deleted via the API but they may be archived by setting the optional parameter archived to true while updating a user. It can also be unarchived by setting the optional parameter archived to false. You cannot archive the account owner.
+A user cannot be deleted via the API but they may be archived by setting the optional parameter archived to true while updating a user. It can also be unarchived by setting the optional parameter archived to false.
 
 ### User Type
 


### PR DESCRIPTION
According to [this card](https://trello.com/c/KB84zaVg/1433-bug-api-update-api-users-are-able-to-archive-the-account-owner-via-the-api), archiving the account owner is permitted via the API. This PR removes the language to the contrary.

@aatrostle Please CR and merge