### PR TITLE
Add optional params to holiday endpoint docs.

### DIFF
--- a/sections/holidays.md
+++ b/sections/holidays.md
@@ -10,7 +10,9 @@ GET /api/v1/holidays
 
 ### Optional Query Parameters
 
-None.
+| **Parameter** | **Description** |
+| ------------- | --------------- |
+| per_page, page |  Parameters for pagination. Default values are per_page = 20 , page = 1 ( the first ) |
 
 ## Fields:
 


### PR DESCRIPTION
## Summary

Update API documentation for the `holidays` endpoint, which appears to paginate results for any user-configured holidays (20 per page is default). This replaces `none` with a table showing the `per_page, page` options. The wording is borrowed from other endpoint documentation that uses this same param.