### PR TITLE
Updating docs: clarifications and listing endpoints at top of each file

### DIFF
--- a/sections/approvals.md
+++ b/sections/approvals.md
@@ -4,6 +4,17 @@
 
 In 10,000ft, certain record types are considered "approvable." Currently, these record types are time entries and expense items. Approvals are created when time entries or expense items are "submitted for approval."
 
+## Endpoints
+
+```
+GET /api/v1/approvals
+
+GET /api/v1/users/<user_id>/time_entries?fields=tags
+
+POST /api/v1/approvals
+
+DELETE /api/v1/approvals/<approval_id>
+```
 
 ## List Approvals
 

--- a/sections/assignments.md
+++ b/sections/assignments.md
@@ -5,16 +5,32 @@
 
 Assignments connect a [User](users.md) to a [Project](projects.md) or a [Phase](phases.md) (part of a project) or a [LeaveType](leave-types.md).
 
+## Endpoints
+
+```
+GET /api/v1/users/<user_id>/assignments
+
+GET /api/v1/projects/<project_id>/assignments
+
+GET /api/v1/users/<user_id>/assignments/<assignment_id>
+
+GET /api/v1/projects/project_id/assignments/<assignment_id>
+
+POST /api/v1/users/<user_id>/assignments
+
+DELETE /api/v1/users/<user_id>/assignments/<assignment_id>
+```
+
 ## List assignments for a User or Project
 
 ##### Optional parameters:
 
 | **Parameter** | **Description** |
 | ------------- | --------------- |
-| from |  get assignments that end after this date |
-| to |  get assignments that start before this date |
-| per_page, page |  Parameters for pagination. Default values are per_page = 20 , page = 1 ( the first ) |
-| with_phases	| true to include assignment to phases ( child projects ) |
+| `from` |  get assignments that end after this date |
+| `to` |  get assignments that start before this date |
+| `per_page`, `page` |  Parameters for pagination. Default values are per_page = 20 , page = 1 ( the first ) |
+| `with_phases`	| true to include assignment to phases ( child projects ) |
 
 ```
 GET /api/v1/users/<user_id>/assignments
@@ -56,7 +72,7 @@ POST /api/v1/users/<user_id>/assignments
 
  curl -d 'leave_id=<leave_id>&starts_at=<YEAR-MO-DAY>&ends_at=<YEAR-MO-DAY>&percent=0.25'  \
                  'https://vnext.10000ft.com/api/v1/users/1/assignments?auth=...'
-                 
+
  curl -d 'leave_id=<leave_id>&starts_at=<YEAR-MO-DAY>&ends_at=<YEAR-MO-DAY>&allocation_mode=hours_per_day&hours_per_day=<hours>'  \
                  'https://vnext.10000ft.com/api/v1/users/1/assignments?auth=...'
 ```

--- a/sections/bill-rates.md
+++ b/sections/bill-rates.md
@@ -32,7 +32,7 @@ POST /api/v1/projects/<project_id>/bill_rates
 
 | **Name** | **Description** |
 | ------ | --------------- |
-| rebuild_assignments | rebuild all assignments for this project with the new bill rate |
+| `rebuild_assignments` | rebuild all assignments for this project with the new bill rate |
 
 ## Fields:
 

--- a/sections/budget-item-categories.md
+++ b/sections/budget-item-categories.md
@@ -4,14 +4,16 @@ Budget item categories are a set of lookup values for your organization which ca
 
 There is an account level definition of budget categories, made available via:
 
-```
-/api/v1/time_entry_categories
-```
-
-or
+## Endpoints
 
 ```
-/api/v1/expense_item_categories 
+GET /api/v1/time_entry_categories
+
+GET /api/v1/expense_item_categories
+
+GET /api/v1/projects/<project_id>/time_entry_categories
+
+GET /api/v1/projects/<project_id>/expense_item_categories
 ```
 
 in the format:

--- a/sections/budget-items.md
+++ b/sections/budget-items.md
@@ -8,6 +8,26 @@ Value for `item_type` could be one of `TimeFees` / `TimeFeesDays` / `Expenses`
 
 `TimeFeesDays` are actually in unit hours.
 
+## Endpoints
+
+```
+GET /api/v1/projects/<project_id>/budget_items
+
+GET /api/v1/budget_items
+
+GET /api/v1/projects/<project_id>/budget_items/<budget_item_id>
+
+GET /api/v1/budget_items/<budget_item_id>
+
+POST /api/v1/projects/<project_id>/budget_items
+
+PUT /api/v1/budget_items/<budget_item_id>
+
+PUT /api/v1/projects/<project_id>/budget_items/<budget_item_id>
+
+DELETE /api/v1/budget_items/<budget_item_id>
+```
+
 ## List Budget Items
 
 ##### Required Parameters:

--- a/sections/custom-fields.md
+++ b/sections/custom-fields.md
@@ -4,6 +4,20 @@
 
 ##### Endpoint `/api/v1/custom_fields`
 
+## Endpoints
+
+```
+GET /api/v1/custom_fields
+
+GET /api/v1/custom_fields/<custom_field_id>
+
+POST /api/v1/custom_fields
+
+PUT /api/v1/custom_fields/<custom_field_id>
+
+DELETE /api/v1/custom_fields/<custom_field_id>
+```
+
 ## Fields:
 
 | **Name** | **Type** | **Description** | **Optional** | **Readonly** |

--- a/sections/disciplines.md
+++ b/sections/disciplines.md
@@ -3,11 +3,13 @@ Disciplines
 
 Disciplines currently must be created and assigned through the UI.
 
-Endpoints:
+## Endpoints
 
-- [Get Disciplines](#get-disciplines)
-- [Get a Discipline](#get-a-discipline)
+```
+GET /api/v1/disciplines
 
+GET GET /api/v1/disciplines/<id>
+```
 
 Get Disciplines
 -------------
@@ -18,7 +20,7 @@ _Optional parameters:_
 
 - Respects [filtering parameters](/README.md#filtering)
 
-###### Example JSON Response
+#### Example JSON Response
 
 ```json
 {
@@ -48,9 +50,9 @@ _Optional parameters:_
 Get a Discipline
 -------------
 
-* `GET /api/v1/disciplines/1` will return the role with the ID of `1`.
+* `GET /api/v1/disciplines/1` will return the discipline with the ID of `1`.
 
-###### Example JSON Response
+#### Example JSON Response
 
 ```json
 {

--- a/sections/expense-entries.md
+++ b/sections/expense-entries.md
@@ -4,15 +4,31 @@
 
 Expense items are reported by a user on a project or leave type.
 
+## Endpoints
+```
+GET /api/v1/users/<user_id>/expense_items
+
+GET /api/v1/users/<user_id>/expense_items/<id>
+
+GET /api/v1/projects/<project_id>/expense_items
+
+GET /api/v1/projects/<project_id>/expense_items/<id>
+
+POST /api/v1/users/<user_id>/expense_items
+
+PUT /api/v1/projects/<project_id>/users/<user_id>/expense_items/<expense_item_id>
+
+DELETE /api/v1/users/<user_id>/expense_items/<expense_items_id>
+```
 ## List Expense Items for a User
 
 ##### Optional parameters:
 
 | **Parameter** | **Description** |
 | ------------- | --------------- |
-| from | get expenses reported on or after this date |
-| to | get expenses reported on or before this date |
-| per_page, page | Parameters for pagination. Default values are per_page = 20 , page = 1 ( the first ) |
+| `from` | get expenses reported on or after this date |
+| `to` | get expenses reported on or before this date |
+| `per_page`, `page` | Parameters for pagination. Default values are per_page = 20 , page = 1 ( the first ) |
 
 ```
 ```

--- a/sections/holidays.md
+++ b/sections/holidays.md
@@ -12,7 +12,7 @@ GET /api/v1/holidays
 
 | **Parameter** | **Description** |
 | ------------- | --------------- |
-| per_page, page |  Parameters for pagination. Default values are per_page = 20 , page = 1 ( the first ) |
+| `per_page`, `page` |  Parameters for pagination. Default values are per_page = 20 , page = 1 ( the first ) |
 
 ## Fields:
 

--- a/sections/leave-types.md
+++ b/sections/leave-types.md
@@ -4,6 +4,14 @@
 
 LeaveType is a subclass of Assignable. You will see the id refering to a project as `assignable_id` in other models. LeaveType is an assignable that you can assign time to, not being part of a project, such as Vacation.
 
+## Endpoints
+
+```
+GET  /api/v1/leave_types
+
+GET  /api/v1/leave_types/<leave_type_id>
+```
+
 ## List Leave Types (index)
 
 ```

--- a/sections/phases.md
+++ b/sections/phases.md
@@ -4,6 +4,19 @@
 
 Phase is a subclass of [Project](projects.md) which is a subclass of Assignable. You will see the id refering to a project as assignable_id in other models. A Phase always has a `parent_id` set to the id of the parent Project.
 
+## Endpoints
+
+```
+GET /api/v1/projects/<project_id>/phases
+
+POST /api/v1/projects/<project_id>/phases
+
+PUT /api/v1/projects/<project_id>/phases/<phase_id>
+
+DELETE /api/v1/projects/<project_id>/phases/<phase_id>
+
+```
+
 ## List Phases for a Project
 
 ```
@@ -22,7 +35,7 @@ curl  -d "phase_name=Winding%20up&starts_at=2013-09-15&ends_at=2013-09-16"  \
 
 ```
 curl  -XPUT -d "phase_name=Another%20Name&"  \
-                         "https://vnext.10000ft.com/api/v1/projects/[project_id]/phases/456?auth=..."
+                         "https://vnext.10000ft.com/api/v1/projects/[project_id]/phases/[phase_id]?auth=..."
 ```
 
 ## Delete a Phase for a Project

--- a/sections/placeholders.md
+++ b/sections/placeholders.md
@@ -4,21 +4,35 @@
 
 Placeholder resources can be used for temporary resourcing on projects where the final resources are not yet known. Placeholders behave quite similarly to users, with a few differences discussed below.
 
+## Endpoints
+
+```
+GET  /api/v1/placeholder_resources/<placeholder_resource_id>
+
+GET  /api/v1/placeholder_resources/<placeholder_resource_id>/assignments
+
+POST  /api/v1/placeholder_resources
+
+PUT  /api/v1/placeholder_resources/<placeholder_resource_id>
+
+DELETE  /api/v1/placeholder_resources/<placeholder_resource_id>
+```
+
 ## List Placeholder Resources (index)
 
 ##### Optional Parameters:
 
 | **Parameter** | **Description** |
 | ------------- | --------------- |
-| fields | A comma separated list of additional fields to include in the response [ "assignments", "custom_field_values"] |
-| per_page, page | Parameters for pagination. Default values are per_page = 20 , page = 1 ( the first ) |
+| `fields` | A comma separated list of additional fields to include in the response [ "assignments", "custom_field_values"] |
+| `per_page`, `page` | Parameters for pagination. Default values are per_page = 20 , page = 1 ( the first ) |
 
 ```
 GET  /api/v1/placeholder_resources
  curl 'https://vnext.10000ft.com/api/v1/placeholder_resources?fields=assignments,custom_field_values&auth=...'
 ```
 
-Note that custom field values can only be accessed if custom fields are enabled for the account. This is only possible for pro plans and up. See [custom fields](/sections/custom fields.md) for details. 
+Note that custom field values can only be accessed if custom fields are enabled for the account. This is only possible for pro plans and up. See [custom fields](/sections/custom fields.md) for details.
 
 ## Show Placeholder
 
@@ -86,7 +100,7 @@ As noted above, placeholders behave similarly to real users in certain cases. Ho
 
 ##### Placeholder Assignments
 
-Assignments can be made, updated, and removed via the [Assignments](/sections/assignments.md) API just as they can for users. 
+Assignments can be made, updated, and removed via the [Assignments](/sections/assignments.md) API just as they can for users.
 The only difference is that this is accessed through the `placeholder_resources` endpoint. In general, for the [Assignments](/sections/assignments.md) API, a placeholder resource ID can be used as the `user_id` parameter.
 
 ```

--- a/sections/project-tags.md
+++ b/sections/project-tags.md
@@ -7,6 +7,16 @@ There are two ways to list project tags:
 *   Get a list of tags for a single project using the `/api/v1/projects/<project_id>/tags` endpoint.
 *   Adding the parameter `fields=tags` when listing/viewing through `/api/v1/projects`
 
+## Endpoints
+
+```
+GET /api/v1/projects/<project_id>/tags
+
+GET /api/v1/projects?fields=tags
+
+POST /api/v1/projects/<project_id>/tags
+```
+
 ## Create and attach tags to projects
 
 Attaching a tag to a project is technically a "find-or-create" operation. If you post a tag with information that does not exist for your organization it will be created and attached to the project specified. If the tag already exists, it will just be attached. If you try to create the same tag multiple times, it will just be attached once.

--- a/sections/project-users.md
+++ b/sections/project-users.md
@@ -2,6 +2,12 @@
 
 ##### Endpoint: `/api/v1/projects/<project_id>/users`
 
+## Endpoints
+
+```
+GET  /api/v1/projects/<project_id>/users
+```
+
 ## List Users for a given Project
 
 Users are associated to a project by [Assignments](assignments.md).
@@ -10,13 +16,13 @@ Users are associated to a project by [Assignments](assignments.md).
 
 | **Parameter** | **Description** |
 | ------------- | --------------- |
-| per_page, page | Parameters for pagination. Default values are per_page = 20 , page = 1 ( the first ) |
-| fields | A comma separated list of additional fields to include in the response, optional values [ "tags", "assignments", "availabilities", "custom_field_values" ] |
-| sort_field | Field to sort the return document. Possible values: `created`, `updated`, `first_name`, `last_name`, `hire_date`, `termination_date` |
-| sort_order | Order to sort the results on. Possible values: `ascending` or `descending` |
-| with_phases |	If set to `true`, includes users who are assigned to phases ( child projects ) |
-| with_archived	| If set to `true`, includes archived users |
-| include_placeholders	| If set to `true`, includes placeholder users |
+| `per_page`, `page` | Parameters for pagination. Default values are per_page = 20 , page = 1 ( the first ) |
+| `fields` | A comma separated list of additional fields to include in the response, optional values [ "tags", "assignments", "availabilities", "custom_field_values" ] |
+| `sort_field` | Field to sort the return document. Possible values: `created`, `updated`, `first_name`, `last_name`, `hire_date`, `termination_date` |
+| `sort_order` | Order to sort the results on. Possible values: `ascending` or `descending` |
+| `with_phases` |	If set to `true`, includes users who are assigned to phases ( child projects ) |
+| `with_archived`	| If set to `true`, includes archived users |
+| `include_placeholders`	| If set to `true`, includes placeholder users |
 
 ## List Users
 

--- a/sections/projects.md
+++ b/sections/projects.md
@@ -6,6 +6,21 @@ Project is a subclass of Assignable. You will see the `id` referring to a projec
 
 Projects where `archived` is set to `true` cannot be updated. You must first unarchive (set `archived` to `false`) before updating the project.
 
+## Endpoints
+
+```
+GET /api/v1/projects
+
+GET  /api/v1/projects/<project_id>
+
+POST  /api/v1/projects
+
+PUT  /api/v1/projects/<project_id>
+
+DELETE  /api/v1/projects/<project_id>
+
+```
+
 ## Project State
 
 `project_state` describes the state of the project:
@@ -20,20 +35,20 @@ Projects where `archived` is set to `true` cannot be updated. You must first una
 
 | **Parameter** | **Description** |
 | ------------- | --------------- |
-| from | get projects that end on or after this date |
-| to | get projects that start on or before this date |
-| strict | set to `true` to restrict the projects to only those contained entirely within the `from` and `to` params |
-| fields | a comma separated list, optional values [ "children", "tags", "budget_items", "project_state" , "phase_count", "summary", "custom_field_values" ] Will add additional fields to the output |
-| filter_field | Specifies the property to filter on. "project_state" is the only supported value |
-| filter_list | The value of "filter_field" to match, outputs will be projects with state matching this value. Possible values: Internal, Tentative, Confirmed |
-| sort_field | Field to sort the return document. Possible values: created or updated |
-| sort_order | order to sort the results on. Possible values: ascending or descending |
-| project_code | project code to find, exact match |
-| phase_name | phase name to find, exact match |
-| with_archived | true to include deleted/archived projects |
-| with_phases | true to include phases ( child projects ) |
-| per_page, page | Parameters for pagination. Default values are per_page = 20 , page = 1 ( the first )|
-| archived | true to archive/false to unarchive |
+| `from` | get projects that end on or after this date |
+| `to` | get projects that start on or before this date |
+| `strict` | set to `true` to restrict the projects to only those contained entirely within the `from` and `to` params |
+| `fields` | a comma separated list, optional values [ "children", "tags", "budget_items", "project_state" , "phase_count", "summary", "custom_field_values" ] Will add additional fields to the output |
+| `filter_field` | Specifies the property to filter on. "project_state" is the only supported value |
+| `filter_list` | The value of "filter_field" to match, outputs will be projects with state matching this value. Possible values: Internal, Tentative, Confirmed |
+| `sort_field` | Field to sort the return document. Possible values: created or updated |
+| `sort_order` | order to sort the results on. Possible values: ascending or descending |
+| `project_code` | project code to find, exact match |
+| `phase_name` | phase name to find, exact match |
+| `with_archived` | true to include deleted/archived projects |
+| `with_phases` | true to include phases ( child projects ) |
+| `per_page`, `page` | Parameters for pagination. Default values are per_page = 20 , page = 1 ( the first )|
+| `archived` | true to archive/false to unarchive |
 
 ## List projects
 
@@ -100,7 +115,7 @@ PUT  /api/v1/projects/1245
 
 ## Locking Time Entries
 
-`timeentry_lockout` is used to control when new time entries are no longer accepted to a project. 
+`timeentry_lockout` is used to control when new time entries are no longer accepted to a project.
 
 | **Value** | **Description** |
 | ------------- | --------------- |
@@ -129,7 +144,7 @@ GET  https://api.10000ft.com/api/v1/projects/<project_id>?fields=tags,summary,ch
 ```
 
 ```
-{  
+{
   "id":821065,
   "archived":false,
   "archived_at":null,
@@ -154,30 +169,30 @@ GET  https://api.10000ft.com/api/v1/projects/<project_id>?fields=tags,summary,ch
   "has_pending_updates":false,
   "client":null,
   "project_state":"Internal",
-  "tags":{  
-    "paging":{  
+  "tags":{
+    "paging":{
       "self":"/api/v1/projects/821065/tags?per_page=1&page=1",
       "next":null,
       "previous":null,
       "page":1,
       "per_page":1
     },
-    "data":[  
-      {  
+    "data":[
+      {
         "id":1207009,
         "value":"Sales"
       }
     ]
   },
-  "children":{  
-    "paging":{  
+  "children":{
+    "paging":{
       "self":"/api/v1/projects/821065/tags?per_page=100000&page=1",
       "next":null,
       "previous":null,
       "page":1,
       "per_page":100000
     },
-    "data":[  
+    "data":[
 
     ]
   },

--- a/sections/roles.md
+++ b/sections/roles.md
@@ -1,12 +1,15 @@
-Roles
-=========
+# Roles
 
 Roles currently must be created and assigned through the UI.
 
-Endpoints:
+## Endpoints
 
-- [Get Roles](#get-roles)
-- [Get a Role](#get-a-role)
+```
+GET /api/v1/roles
+
+GET /api/v1/roles/<id>
+```
+
 
 
 Get Roles
@@ -18,7 +21,7 @@ _Optional parameters:_
 
 - Respects [filtering parameters](/README.md#filtering)
 
-###### Example JSON Response
+#### Example JSON Response
 
 ```json
 {
@@ -47,7 +50,7 @@ Get a Role
 
 * `GET /api/v1/roles/1` will return the role with the ID of `1`.
 
-###### Example JSON Response
+#### Example JSON Response
 
 ```json
 {

--- a/sections/time-entries.md
+++ b/sections/time-entries.md
@@ -2,23 +2,34 @@
 
 Time Entries are a collection of hours tracked per project and user. There are two main kinds of time_entries.
 
-## Suggested time entries
+## Endpoints:
 
-Suggested time entries (also know as unconfirmed time entries) are created by 10,000ft as a result of resources being assigned to a project. These are identifiable by the `is_suggestion: true` attribute on the time entry objects. Suggested time entries are not returned by the API by default and must be requested using the `with_suggestions=true` parameter on the GET API call to fetch time entries.
+```
+# Time entries by user
+GET /api/v1/users/<user_id>/time_entries
+GET /api/v1/users/<user_id>/time_entries/<id>
 
-Suggested time entries are read-only and are kept up to date by 10Kft as the corresponding assignments are updated.
+# Time entries for given date-range
+GET /api/v1/users/<user_id>/time_entries?from=2017-03-14&to=2017-03-21
 
-## Confirmed time entries.
+# Time entries by project
+GET /api/v1/projects/<project_id>/time_entries
+GET /api/v1/projects/<project_id>/time_entries/<id>
 
-Confirmed time entries are what a user (or the API) has explicitly created to indicate that they have spent some time working on a project.
+# All time entries in the account
+GET /api/v1/time_entries
+GET /api/v1/time_entries/<id>
 
-## Time Entries and Resource Only Users
+# Time entries for given date-range
+GET /api/v1/time_entries?from=2017-03-14&to=2017-03-21
 
-Note that just like in the application UI, you cannot create new confirmed time entries for resource only users via the API. You can read suggested time entries for all users via the API.
+# Updating a time entry
+PUT /api/v1/users/<user_id>/time_entries/id
 
-## Bill Rates
+# Deleting a time entry
+DELETE /api/v1/users/<user_id>/time_entries/id
 
-Time entries have an associated bill rate attached to them. When a new time entry is created, 10Kft will determine the appropriate bill rate for it (based on your account and project settings) and assign a values. When reading time entries, you can see this assigned bill rate.
+```
 
 ## Fields
 
@@ -39,44 +50,36 @@ Time entries have an associated bill rate attached to them. When a new time entr
 | `created_at` | date-time | time of creation | | yes |
 | `updated_at` | date-time | time of last update | | yes |
 
-## Endpoints:
+## Time Entries and Resource Only Users
 
-```
-# Time entries by user
-GET /api/v1/users/<user_id>/time_entries
-GET /api/v1/users/<user_id>/time_entries/<id>
+Just like in the application UI, **you cannot create new confirmed time entries for resource only users** via the API. You can read suggested time entries for all users via the API.
 
-# Time entries for given date-range
-GET /api/v1/users/<user_id>/time_entries?from=2017-03-14&to=2017-03-21  
+Note that if you've created useres through the API, they exist as resource only users until they have
+been invited and then logged into the system.
 
-# Time entries by project
-GET /api/v1/projects/<project_id>/time_entries
-GET /api/v1/projects/<project_id>/time_entries/<id>
+## Suggested time entries
 
-# All time entries in the account
-GET /api/v1/time_entries
-GET /api/v1/time_entries/<id>
+Suggested time entries (also know as unconfirmed time entries) are created by 10,000ft as a result of resources being assigned to a project. These are identifiable by the `is_suggestion: true` attribute on the time entry objects. Suggested time entries are not returned by the API by default and must be requested using the `with_suggestions=true` parameter on the GET API call to fetch time entries.
 
-# Time entries for given date-range
-GET /api/v1/time_entries?from=2017-03-14&to=2017-03-21  
+Suggested time entries are read-only and are kept up to date by 10Kft as the corresponding assignments are updated.
 
-# Updating a time entry
-PUT /api/v1/users/<user_id>/time_entries/id
+## Confirmed time entries.
 
-# Deleting a time entry
-DELETE /api/v1/users/<user_id>/time_entries/id
+Confirmed time entries are what a user (or the API) has explicitly created to indicate that they have spent some time working on a project.
 
-```
+## Bill Rates
+
+Time entries have an associated bill rate attached to them. When a new time entry is created, 10Kft will determine the appropriate bill rate for it (based on your account and project settings) and assign a values. When reading time entries, you can see this assigned bill rate.
 
 ### Optional Query Parameters:
 
-| **Name** | **Description** | format |
+| **Name** | **Description** | **format** |
 | ------------- | --------------- | --------------- |
-| from | get projects that start on or after this date | &from=2017-03-14 |
-| to | get projects that end on or before this date | &to=2017-03-21 |
-| sort_field | Field to sort the return document. Possible values: created or updated |
-| sort_order | order to sort the results on. Possible values: ascending or descending |
-| with_suggestions | true to include suggested (unconfirmed) time entries based on assignments on the schedule | &with_suggestions=true |
+| `from` | get projects that start on or after this date | &from=2017-03-14 |
+| `to` | get projects that end on or before this date | &to=2017-03-21 |
+| `sort_field` | Field to sort the return document. Possible values: created or updated |
+| `sort_order` | order to sort the results on. Possible values: ascending or descending |
+| `with_suggestions` | true to include suggested (unconfirmed) time entries based on assignments on the schedule | &with_suggestions=true |
 
 > IMPORTANT: *to* and *from* _must_ be a valid date formatted as `yyyy-mm-dd`
 

--- a/sections/user-availabilities.md
+++ b/sections/user-availabilities.md
@@ -1,3 +1,21 @@
+# User Availabilities
+
+##### Endpoint: `/api/v1/users/<user_id>/availabilities`
+
+## Endpoints:
+
+```
+GET /api/v1/users/<user_id>/availabilities
+
+GET /api/v1/users/<user_id>/availabilities/<id>
+
+PUT /api/v1/users/<user_id>/availabilities/<id>
+
+DELETE /api/v1/users/<user_id>/availabilities/<id>
+
+POST /api/v1/users/<user_id>/availabilities
+```
+
 # Availabilities
 
 In 10,000ft we have the concept of a work week. It defines the days of the week that are to be considered work days and the number of work hours for those days. Given this work week, you can determine the number of work hours per day, in any given date range. The work week is configurable by an account administrator, via the account settings pages.
@@ -17,20 +35,6 @@ Day0 represents Sunday of the week, day1 Monday and so on. This is irrespective 
 Availability block start and end dates specify a date range during which the given custom available hours apply. Both `starts_at` and `ends_at` values are optional. If starts_at is nil, it implies that the given availabilities are to be used infinitely into the past. Similarly a null ends_at implies that the values are to be used infinitely into the future.
 
 Overlapping date ranges in multiple availability blocks for the same user are accepted but will produce unpredictable results.
-
-## Endpoints:
-
-```
-GET /api/v1/users/<user_id>/availabilities
-
-GET /api/v1/users/<user_id>/availabilities/<id>
-
-PUT /api/v1/users/<user_id>/availabilities/<id>
-
-DELETE /api/v1/users/<user_id>/availabilities/<id>
-
-POST /api/v1/users/<user_id>/availabilities
-```
 
 ## Fields:
 

--- a/sections/user-statuses.md
+++ b/sections/user-statuses.md
@@ -15,6 +15,14 @@ Valid statuses are:
 
 A new "current status" is set by simply creating a new status for the user.
 
+## Endpoints
+
+```
+GET /api/v1/users/statuses
+
+POST  /api/v1/users/<user_id>/statuses
+```
+
 ## Show List of Statuses For a User
 
 ```

--- a/sections/user-tags.md
+++ b/sections/user-tags.md
@@ -7,6 +7,16 @@ There are two ways to list user tags:
 *   Get a list of tags for a single user using the `/api/v1/user/<user_id>/tags` endpoint.
 *   Adding the parameter `fields=tags` when listing/viewing through `/api/v1/users`
 
+## Endpoints
+
+```
+GET /api/v1/users/<user_id>/tags
+
+GET /api/v1/users?fields=tags
+
+POST /api/v1/users/<user_id>/tags
+```
+
 ## Create and attach tags to users
 
 Attaching a tag to a user is technically a "find-or-create" operation. If you post a tag with information that does not exist for your organization it will be created and attached to the user specified. If the tag already exists, it will just be attached. If you try to create the same tag multiple times, it will just be attached once.

--- a/sections/users.md
+++ b/sections/users.md
@@ -1,17 +1,7 @@
 # Users
+##### Endpoint: `/api/v1/users`
 
 The users collection allows you to access information about all users in the API.
-
-##### Optional parameters:
-
-| **Parameter** | **Description** |
-| ------------- | --------------- |
-| per_page, page | Parameters for pagination. Default values are per_page = 20 , page = 1 ( the first )|
-| fields | A comma separated list of additional fields to include in the response, optional values [ "tags", "assignments", "availabilities", "custom_field_values" ] |
-| sort_field | Field to sort the return document. Possible values: `created`, `updated`, `first_name`, `last_name`, `hire_date`, `termination_date` |
-| sort_order | Order to sort the results on. Possible values: `ascending` or `descending` |
-| with_archived	| If set to `true`, includes archived users |
-| include_placeholders	| If set to `true`, includes placeholder users |
 
 ## Endpoints
 
@@ -59,6 +49,18 @@ POST /api/v1/users
 | `created_at` | date-time | time of creation | | yes |
 | `updated_at` | date-time | time of last update | | yes |
 
+##### Optional GET parameters:
+
+| **Parameter** | **Description** |
+| ------------- | --------------- |
+| per_page, page | Parameters for pagination. Default values are per_page = 20 , page = 1 ( the first )|
+| fields | A comma separated list of additional fields to include in the response, optional values [ "tags", "assignments", "availabilities", "custom_field_values" ] |
+| sort_field | Field to sort the return document. Possible values: `created`, `updated`, `first_name`, `last_name`, `hire_date`, `termination_date` |
+| sort_order | Order to sort the results on. Possible values: `ascending` or `descending` |
+| with_archived	| If set to `true`, includes archived users |
+| include_placeholders	| If set to `true`, includes placeholder users |
+
+
 ### Deleting vs Archiving
 
 A user cannot be deleted via the API but they may be archived by setting the optional parameter archived to true while updating a user. It can also be unarchived by setting the optional parameter archived to false. You cannot archive the account owner.
@@ -81,7 +83,22 @@ Values not described in this list are reserved for internal/future use.
 
 Setting the user_type_id via API is not supported.
 
+## Create a user
+```
+POST  /api/v1/users
+
+{
+  "first_name": "Chris",
+  "last_name": "James",
+  "email": "chris@example.com",
+}
+```
+Creating a new user creates a resource only user. Resource only users can be used for scheduling. However, if you want the new user to be able to track their time they need to be invited through the `People` tab on your `Account Settings`.
+
 ## Sample Response
+```
+GET  https://api.10000ft.com/api/v1/users/1?auth=<token>
+```
 
 ```
 {

--- a/sections/webhooks.md
+++ b/sections/webhooks.md
@@ -2,21 +2,31 @@
 
 ##### Endpoint: `/api/v1/webhooks`
 
-Webhooks allow users to register, via the API, a webhook 
+Webhooks allow users to register, via the API, a webhook
 that they can use to receive notifications about key events in their account.
 Currently, webhooks are supported for the following events.
 
+## Endpoints
 
+```
+GET /api/v1/webhooks
+
+POST /api/v1/webhooks
+
+DELETE /api/v1/webhooks/<webhook_id>
+```
+
+## Fields:
 | **Event Type** | **Description** |
 | ------------- | --------------- |
-| project.created | fires when a new project is created |
-| project.updated | fires when a project is updated |
-| time.entry.created | fires when a new time entry is created |
-| time.entry.updated | fires when a time entry is updated |
-| user.created | fires when a new time entry is created |
-| user.updated | fires when a user is updated |
-| assignment.created | fires when a new assignment is created |
-| assignment.updated | fires when an assignment is updated |
+| `project.created` | fires when a new project is created |
+| `project.updated` | fires when a project is updated |
+| `time.entry.created` | fires when a new time entry is created |
+| `time.entry.updated` | fires when a time entry is updated |
+| `user.created` | fires when a new time entry is created |
+| `user.updated`| fires when a user is updated |
+| `assignment.created` | fires when a new assignment is created |
+| `assignment.updated` | fires when an assignment is updated |
 
 
 ## List Webhooks
@@ -41,7 +51,7 @@ curl 'https://vnext.10000ft.com/api/v1/webhooks?&auth=..'
 ```
 {
   "paging": {
-   ...  
+   ...
   },
   "data": [
     {
@@ -59,11 +69,11 @@ curl 'https://vnext.10000ft.com/api/v1/webhooks?&auth=..'
 
 **Field** | **Description** |
 | ------------- | --------------- |
-| id | unique identifier for the webhook |
-| organization_id | unique identifier for the organization to which the webhook belongs |
-| url | url associated with the webhook, to which events are posted |
-| status | status of the webhook |
-| event_type | type of event associated with the webhook |
+| `id` | unique identifier for the webhook |
+| `organization_id` | unique identifier for the organization to which the webhook belongs |
+| `url` | url associated with the webhook, to which events are posted |
+| `status` | status of the webhook |
+| `event_type` | type of event associated with the webhook |
 
 #### Webhook Status
 
@@ -83,7 +93,7 @@ POST /api/v1/webhooks
 | event_type | type of event associated with the webhook |
 | url | url to which events should be posted |
 
-Both parameters are required. The 'event_type' must be one of the supported types mentioned above. 
+Both parameters are required. The 'event_type' must be one of the supported types mentioned above.
 The url must be https with a valid host.
 
 ## Deleting a webhook
@@ -98,11 +108,11 @@ This is currently not permitted.
 
 ## Webhook Limits
 
-To prevent repetitive posting of the same webhook payload, no more than 10 webhooks per event type are permitted. 
+To prevent repetitive posting of the same webhook payload, no more than 10 webhooks per event type are permitted.
 
 ## Webhook Payloads
 
-When a webhook is registered for a particular event type with the 10000ft API, 
+When a webhook is registered for a particular event type with the 10000ft API,
 every time an event of that type occurs, a POST is made to the webhook URL containing
 data about the affected object. For example, if a webhook is registered for the project.created
 event, every time a new project is created, a POST with the details of the created project is made to the
@@ -120,8 +130,8 @@ webhook's URL. This POST data is known as the webhook payload. A webhook payload
 The "type" field indicates what type of event occurred, and is always one of the event types listed above.
 The "data" field is exactly the same as what would be returned if the actual object
 were fetched through the API via a GET call. Refer to the [Projects](projects.md), [Users](users.md),
-[Time Entries](time-entries.md) and [Assignments](assignments.md) documentation for the exact format and return values 
-for the GET output. The data is exactly the same as a simple GET call output, with no additional fields 
+[Time Entries](time-entries.md) and [Assignments](assignments.md) documentation for the exact format and return values
+for the GET output. The data is exactly the same as a simple GET call output, with no additional fields
 requested. It is not possible to request additional fields in the webhook payload, e.g. to request custom field values
 or bill rates or other data that can be requested through the 'fields' parameter in typical API calls. If such additional
 data is needed when processing a webhook, it is recommended that you make a GET request using the object ID returned in
@@ -158,7 +168,7 @@ Adding phases to a project does trigger an event, but it is a separate event for
 
 #### Phases
 
-While separate webhooks for phase events do not exist, phase create and update events will be reported on 
+While separate webhooks for phase events do not exist, phase create and update events will be reported on
 project.created and project.updated webhooks.
 
 #### Users
@@ -176,7 +186,7 @@ The following changes do *not* trigger updated events.
 
 ## What should you return from your webhook processing code?
 
-10000ft keeps track of return values from webhook processing code, and if a webhook is behaving poorly e.g. consistently 
+10000ft keeps track of return values from webhook processing code, and if a webhook is behaving poorly e.g. consistently
 unreachable or in error, it may be automatically unsubscribed. Further, returning a 410 code on a webhook will also automatically unsubscribe it.
 
 ## Can Webhooks be viewed or edited from the application front-end?


### PR DESCRIPTION
The bulk of these PR changes move the list of endpoints to the top of every file to add consistency to the docs. 

The real content changes are in [time entries](https://github.com/10Kft/10kft-api/compare/master...kayladavis:update-docs?diff=split#diff-1dca1bafe55881e2fa7026a3b549324e) and [users](https://github.com/10Kft/10kft-api/compare/master...kayladavis:update-docs?diff=split#diff-abf661b85b626300a30b1b42bce41d4c). In these sections I added a bit more information about resource only users. 