### PR TITLE
Update Bill Rates API "rebuild assignment" note to "today + future"

### DIFF
--- a/source/includes/_bill-rates.md
+++ b/source/includes/_bill-rates.md
@@ -30,7 +30,7 @@ POST /api/v1/projects/<project_id>/bill_rates
 
 | **Name** | **Description** |
 | ------ | --------------- |
-| rebuild_assignments | rebuild all assignments for this project with the new bill rate |
+| rebuild_assignments | rebuild ongoing and future assignments for this project with the new bill rate |
 
 ## Fields:
 


### PR DESCRIPTION
Slack discussion: https://smartsheet.slack.com/archives/C03M9TW8C56/p1729527818928809

Current api doc description for "rebuild assignments" is out of date and incorrect. With "rebuild assignments" set to true, only ongoing and future assignments' bill rate will be updated, which doesn't include past assignment. 

Part of ESC-14802 

